### PR TITLE
Change for server relative urls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,10 @@ export class Navigation {
   public static navigate(link: string, fullPageReload: boolean = false) {
     //Including the protocol that you're using  
     if (link.search(/^http[s]?\:\/\//) == -1) {
-      link = '//' + link;
+      //Not starting with a /
+      if(link.search(/^\//) == -1) {
+        link = '/' + link;
+      }
     }
     
     const isLayoutPage = location.href.toLowerCase().indexOf("/_layouts/") !== -1;


### PR DESCRIPTION
I am not sure what the old line should do, but with server relative URLs that was not working. Adding a double slash in front of sites or /sites breaks the URL for SPO.

Refering to issue #8